### PR TITLE
Bump app icon cache-busting references

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,10 +1,10 @@
 # SendMoi Marketing Handoff
 
-Last updated: March 5, 2026
+Last updated: March 6, 2026
 
 ## Branch
 
-- `main`
+- `codex/site-page-edits`
 
 ## Current focus
 
@@ -33,7 +33,7 @@ Last updated: March 5, 2026
   - canonical/OG/twitter URLs now use `https://send.moi`
   - legal links now route to `/privacy/`, `/terms/`, `/accessibility/`
 - Updated app icon references with cache busting:
-  - `app-icon.png?v=20260305-4`
+  - `app-icon.png?v=20260305-5`
 - Updated support email references:
   - `help@mail.moi`
 - Footer refinements:

--- a/accessibility/index.html
+++ b/accessibility/index.html
@@ -7,8 +7,8 @@
     <title>SendMoi Accessibility Statement</title>
     <meta name="description" content="Accessibility Statement for SendMoi by John Niedermeyer." />
     <link rel="canonical" href="https://send.moi/accessibility/" />
-    <link rel="icon" type="image/png" href="../assets/images/sendmoi/app-icon.png?v=20260305-4" />
-    <link rel="apple-touch-icon" href="../assets/images/sendmoi/app-icon.png?v=20260305-4" />
+    <link rel="icon" type="image/png" href="../assets/images/sendmoi/app-icon.png?v=20260305-5" />
+    <link rel="apple-touch-icon" href="../assets/images/sendmoi/app-icon.png?v=20260305-5" />
 
     <script>
       (() => {
@@ -418,7 +418,7 @@
 
       <section class="hero" aria-labelledby="accessibility-title">
         <div class="hero-icon">
-          <img src="../assets/images/sendmoi/app-icon.png?v=20260305-4" alt="SendMoi app icon" width="1024" height="1024" />
+          <img src="../assets/images/sendmoi/app-icon.png?v=20260305-5" alt="SendMoi app icon" width="1024" height="1024" />
         </div>
         <div>
           <p class="eyebrow">SendMoi</p>

--- a/index.html
+++ b/index.html
@@ -10,8 +10,8 @@
       content="SendMoi makes it easy to send links to yourself without losing them in tabs, bookmarks, or chats."
     />
     <link rel="canonical" href="https://send.moi/" />
-    <link rel="icon" type="image/png" href="./assets/images/sendmoi/app-icon.png?v=20260305-4" />
-    <link rel="apple-touch-icon" href="./assets/images/sendmoi/app-icon.png?v=20260305-4" />
+    <link rel="icon" type="image/png" href="./assets/images/sendmoi/app-icon.png?v=20260305-5" />
+    <link rel="apple-touch-icon" href="./assets/images/sendmoi/app-icon.png?v=20260305-5" />
 
     <meta property="og:type" content="website" />
     <meta property="og:locale" content="en_US" />
@@ -22,8 +22,8 @@
     />
     <meta property="og:url" content="https://send.moi/" />
     <meta property="og:site_name" content="John Niedermeyer" />
-    <meta property="og:image" content="https://send.moi/assets/images/sendmoi/app-icon.png?v=20260305-4" />
-    <meta property="og:image:secure_url" content="https://send.moi/assets/images/sendmoi/app-icon.png?v=20260305-4" />
+    <meta property="og:image" content="https://send.moi/assets/images/sendmoi/app-icon.png?v=20260305-5" />
+    <meta property="og:image:secure_url" content="https://send.moi/assets/images/sendmoi/app-icon.png?v=20260305-5" />
     <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="1024" />
     <meta property="og:image:height" content="1024" />
@@ -36,7 +36,7 @@
       content="SendMoi makes it easy to send links to yourself without losing them in tabs, bookmarks, or chats."
     />
     <meta name="twitter:url" content="https://send.moi/" />
-    <meta name="twitter:image" content="https://send.moi/assets/images/sendmoi/app-icon.png?v=20260305-4" />
+    <meta name="twitter:image" content="https://send.moi/assets/images/sendmoi/app-icon.png?v=20260305-5" />
     <meta name="twitter:image:alt" content="SendMoi app icon." />
 
     <script>
@@ -1077,7 +1077,7 @@
       <section class="hero" aria-labelledby="sendmoi-title">
         <div class="hero-content">
           <p class="brand">
-            <img src="./assets/images/sendmoi/app-icon.png?v=20260305-4" alt="SendMoi app icon" width="1024" height="1024" />
+            <img src="./assets/images/sendmoi/app-icon.png?v=20260305-5" alt="SendMoi app icon" width="1024" height="1024" />
             <span>SendMoi</span>
           </p>
 

--- a/privacy/index.html
+++ b/privacy/index.html
@@ -7,8 +7,8 @@
     <title>SendMoi Privacy Policy</title>
     <meta name="description" content="Privacy Policy for SendMoi by John Niedermeyer." />
     <link rel="canonical" href="https://send.moi/privacy/" />
-    <link rel="icon" type="image/png" href="../assets/images/sendmoi/app-icon.png?v=20260305-4" />
-    <link rel="apple-touch-icon" href="../assets/images/sendmoi/app-icon.png?v=20260305-4" />
+    <link rel="icon" type="image/png" href="../assets/images/sendmoi/app-icon.png?v=20260305-5" />
+    <link rel="apple-touch-icon" href="../assets/images/sendmoi/app-icon.png?v=20260305-5" />
 
     <script>
       (() => {
@@ -418,7 +418,7 @@
 
       <section class="hero" aria-labelledby="privacy-title">
         <div class="hero-icon">
-          <img src="../assets/images/sendmoi/app-icon.png?v=20260305-4" alt="SendMoi app icon" width="1024" height="1024" />
+          <img src="../assets/images/sendmoi/app-icon.png?v=20260305-5" alt="SendMoi app icon" width="1024" height="1024" />
         </div>
         <div>
           <p class="eyebrow">SendMoi</p>

--- a/terms/index.html
+++ b/terms/index.html
@@ -7,8 +7,8 @@
     <title>SendMoi Terms of Service</title>
     <meta name="description" content="Terms of Service for SendMoi by John Niedermeyer." />
     <link rel="canonical" href="https://send.moi/terms/" />
-    <link rel="icon" type="image/png" href="../assets/images/sendmoi/app-icon.png?v=20260305-4" />
-    <link rel="apple-touch-icon" href="../assets/images/sendmoi/app-icon.png?v=20260305-4" />
+    <link rel="icon" type="image/png" href="../assets/images/sendmoi/app-icon.png?v=20260305-5" />
+    <link rel="apple-touch-icon" href="../assets/images/sendmoi/app-icon.png?v=20260305-5" />
 
     <script>
       (() => {
@@ -418,7 +418,7 @@
 
       <section class="hero" aria-labelledby="terms-title">
         <div class="hero-icon">
-          <img src="../assets/images/sendmoi/app-icon.png?v=20260305-4" alt="SendMoi app icon" width="1024" height="1024" />
+          <img src="../assets/images/sendmoi/app-icon.png?v=20260305-5" alt="SendMoi app icon" width="1024" height="1024" />
         </div>
         <div>
           <p class="eyebrow">SendMoi</p>


### PR DESCRIPTION
## Summary
- bump app icon cache-busting references from v=20260305-4 to v=20260305-5
- update the homepage and legal pages to reference the refreshed icon URL
- refresh HANDOFF.md for the current branch and icon version

## Testing
- not run (static HTML reference update only)
