### PR TITLE
[codex] Archive standalone send.moi repo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,13 @@
+# Repository Status
+
+This repository is archived/decommissioned.
+
+The active SendMoi marketing/docs source now lives in `sendmoi/docs`.
+
+Do not make new changes or deploy from this repository unless a task explicitly requires historical maintenance here.
+
+## Working guidance
+
+- Prefer the `sendmoi` repository for all active implementation, docs, preview, and deploy work.
+- Treat this repo as historical reference for the retired standalone `send.moi` site.
+- If a one-off historical deploy is ever required from this repo, use `ALLOW_RETIRED_DEPLOY=1` intentionally and reconcile the real source in `sendmoi/docs` afterward.

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,152 +1,25 @@
 # SendMoi Marketing Handoff
 
-Last updated: March 21, 2026
+Last updated: April 13, 2026
 
-## Branch
+## Status
 
-- `codex/flow-front-and-center`
+- This repository is archived/decommissioned.
+- The active SendMoi marketing/docs source now lives in `sendmoi/docs`.
+- Do not make new changes or deploy from this repository.
 
-## Current focus
+## Migration note
 
-- Reposition the homepage so the primary story is the 3-step "save it for later" flow
-- Keep the standalone `send.moi` marketing site documentation accurate for the active branch
+- Treat this repo as historical reference only for the retired standalone `send.moi` site.
+- Active implementation, docs changes, and deploy work should happen from the `sendmoi` repo.
 
-## What changed
+## Operational note
 
-- Repositioned the homepage around the everyday save-for-later flow:
-  - restored the top of the page to the preferred legacy order: brand, headline, subheadline, store badges, and demo video
-  - moved `How it works` out of the hero and into a single full-width module below the fold
-  - simplified that module to a shorter 3-step horizontal story with lightweight visuals
-  - replaced the removed lower feature stack with a concise reassurance section covering likely questions about privacy, account usage, requirements, and offline sending
-  - updated homepage `description`, `og:description`, and `twitter:description` to mention closing tabs and finding the link later
-- Bumped app icon cache-busting query strings from `v=20260310-1` to `v=20260312-1` across homepage and child pages:
-  - updated favicon / apple-touch-icon references in `/`, `/privacy/`, `/terms/`, and `/accessibility/`
-  - updated homepage social preview image references (`og:image`, `og:image:secure_url`, `twitter:image`)
-  - updated visible theme-aware icon references on the homepage and child-page hero sections
-- Expanded `AGENTS.md` guidance for rendered-site work in worktrees:
-  - start or reuse a preview server from the active worktree when needed
-  - reserve port `8000` for the root checkout
-  - use `make dev-thread` / `make dev-live-thread` in worktrees, starting at `8001` and cascading upward
-  - include the exact preview URL in responses when a thread preview server is running
-- Updated issue-handling instructions in `AGENTS.md`:
-  - when an issue is needed and no number is provided, create the next GitHub issue directly instead of asking which number to use
-- Expanded the privacy policy to better spell out Google account access, on-device storage, third-party requests, limited disclosure cases, and Google API Limited Use compliance language.
-- Expanded the terms of service with clearer Google-account responsibilities, acceptable-use restrictions, intellectual property language, termination terms, and governing-law language.
-- Updated support email references across the site and docs to `help@send.moi`.
-- Reworked deploy staging so deploy-specific rewrites do not dirty tracked files:
-  - `scripts/deploy.sh` now copies the site into a temporary staging directory before any rewrites
-  - canonical/social URL rewrites now target the staged pages instead of the working tree
-  - app-icon cache-busting is now hash-based per staged asset instead of date-sequence based in tracked HTML
-  - rsync now deploys the staged site paths, keeping local checked-in files unchanged after deploy
-- Refined homepage value copy to emphasize rich email-card delivery:
-  - updated hero supporting line to `SendMoi sends links to Gmail as rich email cards, so they're easy to find and act on later.`
-  - synced the same line across `description`, `og:description`, and `twitter:description` in `index.html`
-- Bumped app icon cache-busting query strings to `v=20260310-1` across homepage and policy pages:
-  - updated favicon / apple-touch-icon and in-page icon references in `/`, `/privacy/`, `/terms/`, and `/accessibility/`
-  - updated homepage social preview image references (`og:image`, `og:image:secure_url`, `twitter:image`)
-- Reworked the landing-page hero messaging to match the App Store pairing:
-  - title treatment remains `SendMoi`
-  - hero headline now reads `Your inbox, in two taps.`
-  - supporting gray copy now carries the Gmail mention
-- Applied typography wrapping defaults across the site:
-  - `text-wrap: balance` on headings
-  - `text-wrap: pretty` on longer body copy
-- Added repository GitHub issue-handling instructions in `AGENTS.md`:
-  - `BUG:` or `ISSUE:` messages should create GitHub issues directly
-  - infer issue type/labels unless explicitly provided
-  - ask one short follow-up only when required details are missing
-  - include screenshots/videos in the issue body via URL or uploaded repo asset
-- Imported standalone site pages into this repo:
-  - `index.html`
-  - `privacy/index.html`
-  - `terms/index.html`
-  - `accessibility/index.html`
-- Added local development `Makefile` targets:
-  - `make` / `make dev`
-  - `make dev-lan`
-  - `make dev-local`
-  - `make dev-live`
-- Copied required assets into this repo:
-  - `assets/fonts/soehne-{leicht,buch,halbfett}.woff2`
-  - `assets/images/sendmoi/*`
-  - `assets/videos/sendmoi/*`
-- Updated domain and path references for standalone hosting:
-  - canonical/OG/twitter URLs now use `https://send.moi`
-  - legal links now route to `/privacy/`, `/terms/`, `/accessibility/`
-- Updated app icon references with cache busting:
-  - `app-icon.png?v=20260305-5`
-- Updated support email references:
-  - `help@send.moi`
-- Footer refinements:
-  - child-page footer moved outside the content card
-  - child-page footer spacing and link styling aligned with homepage
-  - child pages now omit the top divider line above footer
-  - child-page hero icon/title stay side-by-side on mobile and preserve `SendMoi` casing in the eyebrow label
-- Mobile overflow fix:
-  - constrained `Coming soon` annotation offsets on the landing page so narrow screens do not side-scroll
-- Responsive hero polish:
-  - retained the 2-column hero at larger tablet widths only
-  - added an intermediate stacked breakpoint so the product demo centers and expands to full width sooner
-  - kept App Store badges centered in stacked states and left-aligned in the wider 2-column state
-- Refreshed icon cache-busting references across all pages:
-  - `app-icon.png?v=20260307-1`
-- Updated marketing app icon assets to separate light/dark variants sourced from iOS exports:
-  - added `assets/images/sendmoi/app-icon-light.png` (default/light)
-  - added `assets/images/sendmoi/app-icon-dark.png` (dark)
-  - refreshed `assets/images/sendmoi/app-icon.png` as the light fallback export
-  - homepage and policy/accessibility/terms hero icons now switch by theme (system preference + manual toggle)
-  - favicon tags now include a dark-mode icon variant (`media="(prefers-color-scheme: dark)"`)
-  - social preview metadata uses `app-icon-light.png`
-- Resynced the light/dark icon sources again from `/Users/niederme/~Repos/sendmoi/marketing/app-icons` and bumped live references to `v=20260309-2`
-- Adjusted the marketing color palette to match `/Users/niederme/~Repos/sendmoi/SendMoi/AppIcon.icon`:
-  - remapped primary blue/violet accent tokens to icon-aligned values
-  - updated gradient stops and accent rgba overlays on homepage + policy pages
-  - current text-gradient stops for homepage headline + policy/accessibility titles:
-    - `#2B7FFF` at `0%`
-    - `#8722FB` at `37%`
-    - `#9810FA` at `47%`
-    - `#8722FB` at `58%`
-    - `#6C3DFC` at `67%`
-    - `#2B7FFF` at `89%`
-- Added deploy scripts (based on `nieder.me` deploy flow, production-only):
-  - `scripts/deploy.sh`
-  - `scripts/set-site-url.sh`
-  - defaults: `ssh.suckahs.org` / `suckahs` / `/home2/suckahs/public_html/sendmoi`
-  - supports `DRY_RUN=1` preview mode
-  - auto-updates canonical/social URLs and bumps icon cache-busting for `app-icon-light.png` and `app-icon-dark.png`
-- Video asset cleanup:
-  - replaced `assets/videos/sendmoi/sendmoi-demo-hero.mp4` with a newly recaptured hero recording
-  - removed unused `assets/videos/sendmoi/sendmoi-demo-short.mp4`
-- Replaced placeholder artwork for three feature cards with custom light/dark illustrations:
-  - `Your Gmail, kept private` -> `assets/images/sendmoi/features/02-{Light,Dark}.png`
-  - `Offline queue` -> `assets/images/sendmoi/features/04-{Light,Dark}.png`
-  - `Recent recipients` -> `assets/images/sendmoi/features/05-{Light,Dark}.png`
-
-## Open items
-
-- Replace temporary App Store `href="#"` targets with live store URLs at launch.
-- Run final visual QA on desktop + iPhone Safari for hero transition and footer spacing consistency.
-- Verify the staged deploy output with `DRY_RUN=1 ./scripts/deploy.sh`, then production deploy once SSH access is available from the active machine.
-
-## Local run
-
-- Network + `.local` URL:
-  - `make`
-- Live reload:
-  - `make dev-live`
-- Localhost only:
-  - `make dev-local`
-- Deploy:
-  - `./scripts/deploy.sh`
-- Deploy preview (no remote writes):
-  - `DRY_RUN=1 ./scripts/deploy.sh`
+- `scripts/deploy.sh` is intentionally blocked in this repo.
+- If an emergency historical deploy is ever needed, it must be an explicit one-off override and should be followed by reconciling the real source in `sendmoi/docs`.
 
 ## Resume checklist
 
-1. `git fetch --all`
-2. `git checkout codex/flow-front-and-center`
-3. `git pull --ff-only`
-4. `make`
-5. Validate `/`, `/privacy/`, `/terms/`, `/accessibility/` in browser
-6. Run `DRY_RUN=1 ./scripts/deploy.sh`
-7. Run `./scripts/deploy.sh`
+1. Work from the `sendmoi` repository instead of this one.
+2. Make active site/docs changes under `sendmoi/docs`.
+3. Run preview and deploy commands from `sendmoi`, not from `send.moi`.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,14 @@
 # send.moi
 
-Marketing site for SendMoi.
+Archived repository.
 
-## Routes
+The active SendMoi marketing/docs site now lives in `sendmoi/docs`.
+
+Do not make new changes or deploy from this repository.
+
+This repo is kept only as historical context for the retired standalone `send.moi` site.
+
+## Former routes
 
 - `/` marketing landing page
 - `/privacy/` privacy policy
@@ -13,7 +19,7 @@ Marketing site for SendMoi.
 
 - Footer and policy pages use `help@send.moi`
 
-## UI notes
+## Historical UI notes
 
 - The homepage now puts the everyday usage flow front and center:
   - the topper stays close to the legacy structure: brand, headline, subheadline, store badges, and video demo
@@ -39,6 +45,8 @@ Marketing site for SendMoi.
   - `assets/images/sendmoi/features/05-{Light,Dark}.png`
 
 ## Local dev
+
+Local development in this repo is no longer the source of truth. Use the `sendmoi` repo for active work.
 
 Run this from the repo root:
 
@@ -88,35 +96,4 @@ That binds to localhost only.
 
 ## Deploy
 
-Merging to `main` triggers the GitHub Actions deploy workflow automatically. The workflow:
-
-- loads the dedicated deploy key from the `SSH_PRIVATE_KEY` GitHub secret
-- runs the deploy verifiers before syncing the managed site files to the server over SSH
-
-For manual or local deploys, use the shell script directly:
-
-```bash
-./scripts/deploy.sh
-```
-
-Preview only (no remote changes):
-
-```bash
-DRY_RUN=1 ./scripts/deploy.sh
-```
-
-Defaults mirror the current `nieder.me` deploy host/user and deploy to:
-- `DEPLOY_HOST=ssh.suckahs.org`
-- `DEPLOY_USER=suckahs`
-- `DEPLOY_PATH=/home2/suckahs/public_html/sendmoi`
-- `DEPLOY_PORT=22`
-- `SITE_URL=https://send.moi`
-- `DEPLOY_IDENTITY_FILE` optional override for the SSH key path
-
-Override as needed, for example:
-
-```bash
-DEPLOY_PATH=/home2/suckahs/public_html/custom-sendmoi ./scripts/deploy.sh
-```
-
-`deploy.sh` stages a temporary deploy tree, updates canonical/social URLs there, applies hash-based cache-bust query strings for `app-icon-light.png`, `app-icon-dark.png`, and `app-icon.png`, and prefers `~/.ssh/send_moi_deploy` automatically when present. GitHub Actions wiring is checked by `scripts/check-github-deploy.py`.
+Deployments from this repo are intentionally disabled. Deploy from `sendmoi/docs` instead.

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,6 +1,21 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+ALLOW_RETIRED_DEPLOY="${ALLOW_RETIRED_DEPLOY:-0}"
+
+if [[ "$ALLOW_RETIRED_DEPLOY" != "1" ]]; then
+  cat >&2 <<'EOF'
+This repository is decommissioned.
+
+The active SendMoi marketing/docs site now lives in `sendmoi/docs`.
+Deploy from the `sendmoi` repository instead of `send.moi`.
+
+If you intentionally need a one-off historical deploy from this retired repo,
+rerun with `ALLOW_RETIRED_DEPLOY=1`.
+EOF
+  exit 1
+fi
+
 # Deploy static site files over SSH + rsync.
 # Defaults can be overridden via env vars:
 #   DEPLOY_HOST


### PR DESCRIPTION
## What changed
- mark this repository as archived/decommissioned in the README
- replace the handoff doc with a short migration note pointing to `sendmoi/docs`
- block deploys from this repo by default unless `ALLOW_RETIRED_DEPLOY=1` is explicitly set
- update the GitHub repo description to note that the source moved to `sendmoi/docs`

## Why
The active SendMoi marketing/docs source has moved into the `sendmoi` repository, so this standalone repo should stop acting like the source of truth or an active deploy target.

## Impact
- contributors are redirected to the correct repo and path
- accidental deploys from the retired repo are prevented
- the repo is ready to be archived after this lands on `main`

## Validation
- ran `./scripts/deploy.sh` and verified it exits with the decommission message
- reviewed the README, HANDOFF, and deploy-script diff for archival accuracy